### PR TITLE
2.0 preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/bower_components
+/bower_components*
+/bower-*.json
 /.idea

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "paper-tree",
   "main": "paper-tree.html",
-  "version": "1.0.3",
+  "version": "2.0-preview",
   "description": "A custom element displaying a browsable tree.",
   "keywords": [
     "tree",
@@ -16,19 +16,38 @@
     "Florian Maffini <florian.maffini@free.fr>"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.7.0",
-    "paper-menu": "PolymerElements/paper-menu#^1.2.2",
-    "paper-menu-button": "PolymerElements/paper-menu-button#^1.5.2",
-    "paper-icon-button": "PolymerElements/paper-icon-button#^1.1.4",
-    "paper-item": "PolymerElements/paper-item#^1.2.1",
-    "iron-icons": "PolymerElements/iron-icons#^1.2.0",
-    "iron-icon": "PolymerElements/iron-icon#^1.0.12"
+    "polymer": "Polymer/polymer#^2.0.0-rc.3",
+    "paper-listbox": "PolymerElements/paper-listbox#2.0-preview",
+    "paper-menu-button": "PolymerElements/paper-menu-button#2.0-preview",
+    "paper-icon-button": "PolymerElements/paper-icon-button#2.0-preview",
+    "paper-item": "PolymerElements/paper-item#2.0-preview",
+    "iron-icons": "PolymerElements/iron-icons#2.0-preview",
+    "iron-icon": "PolymerElements/iron-icon#2.0-preview"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-    "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
+    "web-component-tester": "^6.0.0-prerelease.5",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.5",
+    "web-animations-js": "^2.2.5"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.7.0",
+        "paper-listbox": "PolymerElements/paper-listbox#^1.1.3",
+        "paper-menu-button": "PolymerElements/paper-menu-button#^1.5.2",
+        "paper-icon-button": "PolymerElements/paper-icon-button#^1.1.4",
+        "paper-item": "PolymerElements/paper-item#^1.2.1",
+        "iron-icons": "PolymerElements/iron-icons#^1.2.0",
+        "iron-icon": "PolymerElements/iron-icon#^1.0.12"
+      },
+      "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+        "web-component-tester": "^4.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+      }
+    }
   }
 }
-

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,7 +7,7 @@
     <title>paper-tree Demo</title>
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-    <link rel="import" href="../../web-animations-js/web-animations-next-lite.min.html">
+    <link rel="import" href="../../web-animations-js/web-animations-next-lite.min.html"> <!-- Shim for KeyframeEffect, used in neon-animation/fade-in-animation (from paper-menu-button). The KeyframeEffect exception did however not appear in pre 2.0... -->
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
     <link rel="import" href="../paper-tree.html">
@@ -178,21 +178,6 @@
         <template>
             <dom-bind>
                 <template is="dom-bind">
-                    <custom-style>
-                        <style is="custom-style">
-                            @keyframes blinker {
-                              50% { opacity: 0; }
-                            }
-
-                            #tree {
-                                --paper-tree-toggle-theme: {
-                                    animation: blinker 1s linear infinite;
-                                    content: '⧖';
-                                    margin-left: -21px;
-                                };
-                            }
-                        </style>
-                    </custom-style>
 
                     <paper-tree id="tree" on-toggle="onToggle" data='{"name": "Loading..."}'></paper-tree>
 
@@ -222,19 +207,7 @@
                         },
 
                         template.setLoadingState = function(node, enabled) {
-
-                            if (!node.customStyle) {
-                                console.log("TODO: customStyle has been removed from Polymer 2.0, and updateStyles does not appear to work for at-rules and mixins.");
-                                return;
-                            }
-
-                            if (enabled) {
-                                node.customStyle['--paper-tree-toggle-theme'] = 'animation: blinker 1s linear infinite; content: \'⧖\'; margin-left: -21px;';
-                            } else {
-                                node.customStyle['--paper-tree-toggle-theme'] = ';';
-                            }
-
-                            node.updateStyles();
+                            node.set('data.loading', enabled);
                         },
 
                         template.fetchChildren = function(node) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,11 +7,14 @@
     <title>paper-tree Demo</title>
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
+    <link rel="import" href="../../web-animations-js/web-animations-next-lite.min.html">
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
     <link rel="import" href="../paper-tree.html">
 
-    <style is="custom-style" include="demo-pages-shared-styles"></style>
+    <custom-style>
+        <style is="custom-style" include="demo-pages-shared-styles"></style>
+    </custom-style>
 </head>
 <body>
 
@@ -173,81 +176,90 @@
     <h3>Lazy loading demo</h3>
     <demo-snippet>
         <template>
-            <template id="t" is="dom-bind">
-                <style is="custom-style">
-                    @keyframes blinker {
-                      50% { opacity: 0; }
-                    }
+            <dom-bind>
+                <template is="dom-bind">
+                    <custom-style>
+                        <style is="custom-style">
+                            @keyframes blinker {
+                              50% { opacity: 0; }
+                            }
 
-                    #tree {
-                        --paper-tree-toggle-theme: {
-                            animation: blinker 1s linear infinite;
-                            content: '⧖';
-                            margin-left: -21px;
-                        };
-                    }
-                </style>
+                            #tree {
+                                --paper-tree-toggle-theme: {
+                                    animation: blinker 1s linear infinite;
+                                    content: '⧖';
+                                    margin-left: -21px;
+                                };
+                            }
+                        </style>
+                    </custom-style>
 
-                <paper-tree id="tree" on-toggle="onToggle" data='{"name": "Loading..."}'></paper-tree>
+                    <paper-tree id="tree" on-toggle="onToggle" data='{"name": "Loading..."}'></paper-tree>
 
-                <script>
+                    <script>
 
-                    var template = document.querySelector('#t'),
-                        tree = template.$.tree;
+                        var template = document.querySelector('dom-bind'),
+                            tree = template.$.tree;
 
-                    // Update the root data after 1 second delay
-                    window.setTimeout(function() {
-                        tree.data = { name:'Cronos' };
-                        // Fetching root children ...
-                        template.fetchChildren(tree.$.root);
-                    }, 1000);
-
-
-                    template.onToggle = function(event) {
-                        var target = event.detail;
-
-                        if (!target.loaded) {
-                            target.loaded = true;
-                            target.getChildren().forEach(function(child){
-                                // Fetching children ...
-                                this.fetchChildren(child);
-                            }, this);
-                        }
-                    },
-
-                    template.setLoadingState = function(node, enabled) {
-
-                        if (enabled) {
-                            node.customStyle['--paper-tree-toggle-theme'] = 'animation: blinker 1s linear infinite; content: \'⧖\'; margin-left: -21px;';
-                        } else {
-                            node.customStyle['--paper-tree-toggle-theme'] = ';';
-                        }
-
-                        node.updateStyles();
-                    },
-
-                    template.fetchChildren = function(node) {
-
-                        // Set loading styles
-                        this.setLoadingState(node, true);
-
+                        // Update the root data after 1 second delay
                         window.setTimeout(function() {
+                            tree.data = { name:'Cronos' };
+                            // Fetching root children ...
+                            template.fetchChildren(tree.$.root);
+                        }, 1000);
 
-                            // Add children to the node
-                            node.set('data.children', [
-                                {name: 'Zeus'},
-                                {name: 'Apollo'},
-                                {name: 'Athena'},
-                                {name: 'Poseidon'}
-                            ]);
 
-                            // Reset loading styles
-                            this.setLoadingState(node, false);
+                        template.onToggle = function(event) {
+                            var target = event.detail;
 
-                        }.bind(this), Math.floor(Math.random() * 2000));
-                    }
-                </script>
-            </template>
+                            if (!target.loaded) {
+                                target.loaded = true;
+                                target.getChildren().forEach(function(child){
+                                    // Fetching children ...
+                                    this.fetchChildren(child);
+                                }, this);
+                            }
+                        },
+
+                        template.setLoadingState = function(node, enabled) {
+
+                            if (!node.customStyle) {
+                                console.log("TODO: customStyle has been removed from Polymer 2.0, and updateStyles does not appear to work for at-rules and mixins.");
+                                return;
+                            }
+
+                            if (enabled) {
+                                node.customStyle['--paper-tree-toggle-theme'] = 'animation: blinker 1s linear infinite; content: \'⧖\'; margin-left: -21px;';
+                            } else {
+                                node.customStyle['--paper-tree-toggle-theme'] = ';';
+                            }
+
+                            node.updateStyles();
+                        },
+
+                        template.fetchChildren = function(node) {
+
+                            // Set loading styles
+                            this.setLoadingState(node, true);
+
+                            window.setTimeout(function() {
+
+                                // Add children to the node
+                                node.set('data.children', [
+                                    {name: 'Zeus'},
+                                    {name: 'Apollo'},
+                                    {name: 'Athena'},
+                                    {name: 'Poseidon'}
+                                ]);
+
+                                // Reset loading styles
+                                this.setLoadingState(node, false);
+
+                            }.bind(this), Math.floor(Math.random() * 2000));
+                        }
+                    </script>
+                </template>
+            </dom-bind>
         </template>
     </demo-snippet>
 

--- a/demo/lazyloading.html
+++ b/demo/lazyloading.html
@@ -8,19 +8,21 @@
 <body>
 
 <template id="t" is="dom-bind">
-    <style is="custom-style">
-        @keyframes blinker {
-          50% { opacity: 0; }
-        }
+    <custom-style>
+        <style is="custom-style">
+            @keyframes blinker {
+              50% { opacity: 0; }
+            }
 
-        #tree {
-            --paper-tree-toggle-theme: {
-                animation: blinker 1s linear infinite;
-                content: '⧖';
-                margin-left: -21px;
-            };
-        }
-    </style>
+            #tree {
+                --paper-tree-toggle-theme: {
+                    animation: blinker 1s linear infinite;
+                    content: '⧖';
+                    margin-left: -21px;
+                };
+            }
+        </style>
+    </custom-style>
     <h2>Lazy loading paper-tree demo</h2>
     <p>
         Here we use the 'toggle' event to lazy load grandchildren.<br>
@@ -54,13 +56,18 @@
 
     template.setLoadingState = function(node, enabled) {
 
-        if (enabled) {
-            node.customStyle['--paper-tree-toggle-theme'] = 'animation: blinker 1s linear infinite; content: \'⧖\'; margin-left: -21px;';
-        } else {
-            node.customStyle['--paper-tree-toggle-theme'] = ';';
-        }
+         if (!node.customStyle) {
+             console.log("TODO: customStyle has been removed from Polymer 2.0, and updateStyles does not appear to work for at-rules and mixins.");
+             return;
+         }
+         
+         if (enabled) {
+             node.customStyle['--paper-tree-toggle-theme'] = 'animation: blinker 1s linear infinite; content: \'⧖\'; margin-left: -21px;';
+         } else {
+             node.customStyle['--paper-tree-toggle-theme'] = ';';
+         }
 
-        node.updateStyles();
+         node.updateStyles();
     },
 
     template.fetchChildren = function(node) {

--- a/demo/lazyloading.html
+++ b/demo/lazyloading.html
@@ -7,22 +7,7 @@
 </head>
 <body>
 
-<template id="t" is="dom-bind">
-    <custom-style>
-        <style is="custom-style">
-            @keyframes blinker {
-              50% { opacity: 0; }
-            }
-
-            #tree {
-                --paper-tree-toggle-theme: {
-                    animation: blinker 1s linear infinite;
-                    content: '⧖';
-                    margin-left: -21px;
-                };
-            }
-        </style>
-    </custom-style>
+<dom-bind><template is="dom-bind">
     <h2>Lazy loading paper-tree demo</h2>
     <p>
         Here we use the 'toggle' event to lazy load grandchildren.<br>
@@ -31,7 +16,7 @@
     <paper-tree id="tree" on-toggle="onToggle" data='{"name": "Loading..."}'></paper-tree>
     <script>
 
-    var template = document.querySelector('#t'),
+    var template = document.querySelector('dom-bind'),
         tree = template.$.tree;
 
     // Update the root data after 1 second delay
@@ -55,19 +40,7 @@
     },
 
     template.setLoadingState = function(node, enabled) {
-
-         if (!node.customStyle) {
-             console.log("TODO: customStyle has been removed from Polymer 2.0, and updateStyles does not appear to work for at-rules and mixins.");
-             return;
-         }
-         
-         if (enabled) {
-             node.customStyle['--paper-tree-toggle-theme'] = 'animation: blinker 1s linear infinite; content: \'⧖\'; margin-left: -21px;';
-         } else {
-             node.customStyle['--paper-tree-toggle-theme'] = ';';
-         }
-
-         node.updateStyles();
+         node.set('data.loading', enabled);
     },
 
     template.fetchChildren = function(node) {
@@ -91,7 +64,7 @@
         }.bind(this), Math.floor(Math.random() * 2000));
     }
 </script>
-</template>
+</template></dom-bind>
 
 
 </body>

--- a/demo/playground.html
+++ b/demo/playground.html
@@ -3,7 +3,7 @@
 <html>
 <head>
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../../web-animations-js/web-animations-next-lite.min.html"> <!-- Shim for KeyframeEffect, used in neon-animation/fade-in-animation (from paper-menu-button). The exception did not appear in pre 2.0. -->
+    <link rel="import" href="../../web-animations-js/web-animations-next-lite.min.html"> <!-- Shim for KeyframeEffect, used in neon-animation/fade-in-animation (from paper-menu-button). The KeyframeEffect exception did however not appear in pre 2.0... -->
 
     <link rel="import" href="../paper-tree.html" />
 </head>

--- a/demo/playground.html
+++ b/demo/playground.html
@@ -3,11 +3,12 @@
 <html>
 <head>
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../../web-animations-js/web-animations-next-lite.min.html"> <!-- Shim for KeyframeEffect, used in neon-animation/fade-in-animation (from paper-menu-button). The exception did not appear in pre 2.0. -->
 
     <link rel="import" href="../paper-tree.html" />
 </head>
 <body>
-<template is="dom-bind">
+<dom-bind><template is="dom-bind">
     <h3>GOT Tree: {{selected.data.name}}</h3>
     <paper-tree selected="{{selected}}"></paper-tree>
     <script>
@@ -32,9 +33,9 @@
             ]
         };
     </script>
-</template>
+</template></dom-bind>
 
-<template is="dom-bind">
+<dom-bind><template is="dom-bind">
     <h3>Media Tree</h3>
     <paper-tree data='{
     "name": "Media Center",
@@ -57,6 +58,6 @@
         "event": "play"
     }]'>
     </paper-tree>
-</template>
+</template></dom-bind>
 </body>
 </html>

--- a/paper-tree-node.html
+++ b/paper-tree-node.html
@@ -76,6 +76,16 @@ Custom property | Description | Default
                 content: '\2212';
             }
 
+             @keyframes blinker {
+                 50% { opacity: 0; }
+             }
+
+            .node-preicon.loading:before {
+                animation: blinker 1s linear infinite;
+                content: '⧖';
+                margin-left: -21px;
+            }
+
             .node-preicon, .node-name {
                 cursor: pointer;
             }
@@ -198,9 +208,20 @@ Custom property | Description | Default
          * @return {string} The class name indicating whether the node is open or closed
          */
         _computeClass: function(change) {
-            var open = change && change.base && change.base.open;
-            var children = change && change.base && change.base.children;
-            return 'node-preicon ' + ((open && children && children.length) ? 'expanded' : children && children.length ? 'collapsed' : '');
+            var cls = 'node-preicon',
+                data = change && change.base;
+            if (!data) return cls;
+
+            if (data.loading) {
+                cls += ' loading';
+            } else if (!data.children || !data.children.length) {
+                // No children => no preicon
+            } else if(data.open) {
+                cls += ' expanded';
+            } else {
+                cls += ' collapsed';
+            }
+            return cls;
         },
 
         /**

--- a/paper-tree-node.html
+++ b/paper-tree-node.html
@@ -3,7 +3,7 @@
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../paper-menu-button/paper-menu-button.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../paper-menu/paper-menu.html">
+<link rel="import" href="../paper-listbox/paper-listbox.html">
 <link rel="import" href="../paper-item/paper-item.html">
 
 <!--
@@ -33,81 +33,81 @@ Custom property | Description | Default
 
 <dom-module id="paper-tree-node">
 
-    <style>
-
-        :host(.selected) > .node-container > .node-row {
-            background-color: var(--paper-tree-selected-background-color, rgba(200, 200, 200, 0.5));
-            color: var(--paper-tree-selected-color, inherit);
-        }
-
-        :host(.selected) > .node-container > .node-row > #actions {
-            display: inline-block;
-        }
-
-        .node-container {
-            white-space: nowrap;
-        }
-
-        .node-row {
-            padding-left: 4px;
-            padding-right: 4px;
-        }
-
-        .node-preicon.collapsed,
-        .node-preicon.expanded {
-            padding-left: 0px;
-        }
-
-        .node-preicon {
-            padding-left: 18px;
-        }
-
-        .node-preicon:before {
-            margin-right: 5px;
-            @apply(--paper-tree-toggle-theme);
-        }
-
-        .node-preicon.collapsed:before {
-            content: '\002B';
-        }
-
-        .node-preicon.expanded:before {
-            content: '\2212';
-        }
-
-        .node-preicon, .node-name {
-            cursor: pointer;
-        }
-
-        .node-icon {
-            cursor: pointer;
-            width: 24px;
-            height: 24px;
-            @apply(--paper-tree-icon-theme);
-        }
-
-        #actions {
-            display: none;
-            float: right;
-            padding: 0;
-            top: -8px; /* cancel the padding of `paper-icon-button`. */
-        }
-
-        ul {
-            margin: 0;
-            padding-left: 20px;
-        }
-
-        li {
-            list-style-type: none;
-        }
-
-        [hidden] {
-            display: none;
-        }
-    </style>
-
     <template>
+        <style>
+
+            :host(.selected) > .node-container > .node-row {
+                background-color: var(--paper-tree-selected-background-color, rgba(200, 200, 200, 0.5));
+                color: var(--paper-tree-selected-color, inherit);
+            }
+
+            :host(.selected) > .node-container > .node-row > #actions {
+                display: inline-block;
+            }
+
+            .node-container {
+                white-space: nowrap;
+            }
+
+            .node-row {
+                padding-left: 4px;
+                padding-right: 4px;
+            }
+
+            .node-preicon.collapsed,
+            .node-preicon.expanded {
+                padding-left: 0px;
+            }
+
+            .node-preicon {
+                padding-left: 18px;
+            }
+
+            .node-preicon:before {
+                margin-right: 5px;
+                @apply --paper-tree-toggle-theme;
+            }
+
+            .node-preicon.collapsed:before {
+                content: '\002B';
+            }
+
+            .node-preicon.expanded:before {
+                content: '\2212';
+            }
+
+            .node-preicon, .node-name {
+                cursor: pointer;
+            }
+
+            .node-icon {
+                cursor: pointer;
+                width: 24px;
+                height: 24px;
+                @apply --paper-tree-icon-theme;
+            }
+
+            #actions {
+                display: none;
+                float: right;
+                padding: 0;
+                top: -8px; /* cancel the padding of `paper-icon-button`. */
+            }
+
+            ul {
+                margin: 0;
+                padding-left: 20px;
+            }
+
+            li {
+                list-style-type: none;
+            }
+
+            [hidden] {
+                display: none;
+            }
+        </style>
+
         <div class="node-container">
             <div class="node-row">
                 <span class$="{{_computeClass(data.*)}}" on-click="toggleChildren"></span>
@@ -115,12 +115,12 @@ Custom property | Description | Default
                 <span class="node-name" on-click="select">{{data.name}}</span>
                 <template is="dom-if" if="{{actions}}">
                     <paper-menu-button id="actions">
-                        <paper-icon-button icon="more-vert" noink class="dropdown-trigger"></paper-icon-button>
-                        <paper-menu class="dropdown-content">
+                        <paper-icon-button icon="more-vert" noink slot="dropdown-trigger"></paper-icon-button>
+                        <paper-listbox slot="dropdown-content">
                             <template is="dom-repeat" items="{{actions}}">
                                 <paper-item on-click="_actionClicked">{{item.label}}</paper-item>
                             </template>
-                        </paper-menu>
+                        </paper-listbox>
                     </paper-menu-button>
                 </template>
             </div>

--- a/test/paper-tree-node.test.html
+++ b/test/paper-tree-node.test.html
@@ -28,18 +28,18 @@ suite('<paper-tree-node>', function() {
     test('properly computes its classes', function() {
         // Some defaults tests
         var answer = node._computeClass();
-        assert.equal(answer, 'node-preicon ');
+        assert.equal(answer, 'node-preicon');
 
         answer = node._computeClass({});
-        assert.equal(answer, 'node-preicon ');
+        assert.equal(answer, 'node-preicon');
 
         // Ask for expanded with no children
         answer = node._computeClass({base: {open: true}});
-        assert.equal(answer, 'node-preicon ');
+        assert.equal(answer, 'node-preicon');
 
         // Ask for expanded with empty children
         answer = node._computeClass({base: {open: true, children:[]}});
-        assert.equal(answer, 'node-preicon ');
+        assert.equal(answer, 'node-preicon');
 
         // Ask for collapsed with children
         answer = node._computeClass({base: {open: false, children:[0]}});
@@ -48,6 +48,10 @@ suite('<paper-tree-node>', function() {
         // Ask for expanded with children
         answer = node._computeClass({base: {open: true, children:[0]}});
         assert.equal(answer, 'node-preicon expanded');
+
+        // Ask for loading with children
+        answer = node._computeClass({base: {loading: true, children:[0]}});
+        assert.equal(answer, 'node-preicon loading');
     });
 
     test('properly computes its icon', function() {


### PR DESCRIPTION
Polymer 2.0 hybrid element, intended for a `2.0-preview` branch.

Tested on Ubuntu 16.04, on Chrome 58 and FF 53.

* 'polymer build' is currently broken, see https://github.com/PolymerElements/paper-button/issues/162
* Lazy loading is now supported by the component; the --paper-tree-toggle-theme is however retained for 1.0 compat (untested).
* Replaced paper-menu with paper-listbox, since paper-menu does not yet have a 2.0-preview branch.
* Added direct dep to web-animations-js to get rid of "Uncaught ReferenceError: KeyframeEffect is not defined".